### PR TITLE
Add time field to post request

### DIFF
--- a/src/core/core.py
+++ b/src/core/core.py
@@ -40,7 +40,10 @@ def data():
 
         identifier = request.json.get('identifier', None)
         request_data = request.json['data']
+
         time = datetime.datetime.now()
+        if 'time' in request.json:
+            time = request.json['time']
 
         try:
             cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)


### PR DESCRIPTION
Add ability to specify time in the logging request. This lets sensors log past events e.g. where network was unreachable